### PR TITLE
change {after-code} to [after-code] according to document of the titlesec macro package

### DIFF
--- a/LaTeX-cn/chapters/LaTeX-Advanced-Skills.tex
+++ b/LaTeX-cn/chapters/LaTeX-Advanced-Skills.tex
@@ -320,7 +320,7 @@ L\hrulefill Mid\dotfill R
 对于需要详细处理标签、标题文字两部分的情况，\pkg{titlesec}宏包还提供了一个\latexline{titleformat}命令．调用方式：
 \begin{latex}
 \titleformat{`\itshape command`}[`\itshape shape`]{`\itshape format`}{`\itshape label`}{`\itshape sep`}
-    {`\itshape before-code`}{`\itshape after-code`}
+    {`\itshape before-code`}[`\itshape after-code`]
 \end{latex}
 
 它们对应的含义如下：


### PR DESCRIPTION
The last parameter is optional, not mandatory.