### PR TITLE
调整 linespread 值为 ctex 宏集默认

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 *.lof
 *.lot
 *.listing
+*.fdb_latexmk
+*.fls
+*.xdv
 
 # Ignored Project
 githubPush-cn

--- a/LaTeX-cn/Head.tex
+++ b/LaTeX-cn/Head.tex
@@ -2,7 +2,7 @@
 % \sups命令可能被重定义,xeCJK放在tipa后
 \RequirePackage[safe]{tipa}
 
-\documentclass[a4paper, zihao=-4, linespread=1]{ctexrep}
+\documentclass[a4paper, zihao=-4]{ctexrep}
 \renewcommand{\CTEXthechapter}{\thechapter}
 % 最小行间间距设定
 \setlength{\lineskiplimit}{3pt}

--- a/LaTeX-cn/chapters/LaTeX-Advanced-Skills.tex
+++ b/LaTeX-cn/chapters/LaTeX-Advanced-Skills.tex
@@ -236,7 +236,7 @@ L\hrulefill Mid\dotfill R
 \end{codeshow}
 
 \subsection{行距}
-\LaTeX\ 的行距由基线计算，可以使用命令\latexline{linespread\{num\}}，默认的基线距离\latexline{baselineskip}是1.2倍的文字高。所以默认行距是1.2倍；如果更改linespread为1.3，那么行距变为$1.2\times 1.3=1.56$倍——这也是ctex文档类的做法。
+\LaTeX\ 的行距由基线计算，可以使用命令\latexline{linespread\{num\}}，默认的基线距离\latexline{baselineskip}是1.2倍的文字高。所以默认行距是1.2倍；如果更改linespread为1.3，那么行距变为$1.2\times 1.3=1.56$倍——这也是ctex文档类的默认做法。
 
 此外还有\latexline{lineskiplimit}和\latexline{lineskip}命令。有时候在两行之间，可能包含较高的内容（比如分式$\dfrac{1}{2}$），使得前一行底部与后一行顶部的距离小于limit值，则此时行距会从由\latexline{linespread}改为由\latexline{lineskip}控制。本手册采用：
 \begin{latex}

--- a/LaTeX-cn/chapters/LaTeX-Basics.tex
+++ b/LaTeX-cn/chapters/LaTeX-Basics.tex
@@ -430,11 +430,11 @@ Let's change font to \myfont{ppl}{Palatino}!
 \subsection{中文支持与CJK字体}
 中文方面，\pkg{ctex}宏包直接定义了新的中文文档类ctexart, ctexrep与ctexbook，以及ctexbeamer幻灯文档类。例如本手册\texttt{Head.tex}中：
 \begin{latex}
-\documentclass[a4paper, zihao=-4, linespread=1]{ctexrep}
+\documentclass[a4paper, zihao=-4]{ctexrep}
   \renewcommand{\CTEXthechapter}{\thechapter}
 \end{latex}
 
-以上设置字号为小四，行距因子为1（故行距为$1\times 1.2=1.2$倍，其中1.2是\LaTeX\ 默认的基线间距）。而a4paper选项继承与原生文档类report，可见ctex文档类还是很好地保留了原生文档类的特征。\RED{值得注意的是，ctex文档类会用\texttt{\char92 CTEX}开头的计数器命令代替原有的}，除非你使用\texttt{scheme=plain}来让ctex文档类\uline{仅支持中文而不做任何文档细节更改}。具体的使用参考ctex宏包文档。
+以上设置纸张大小为A4，字号为小四。a4paper选项继承于原生文档类report，可见ctex文档类还是很好地保留了原生文档类的特征。\RED{值得注意的是，ctex文档类会用\texttt{\char92 CTEX}开头的计数器命令代替原有的}，除非你使用\texttt{scheme=plain}来让ctex文档类\uline{仅支持中文而不做任何文档细节更改}。具体的使用参考ctex宏包文档。
 
 \pkg{ctex}宏包支持以下字体命令：
 \begin{center}


### PR DESCRIPTION
现在的文档中设置了 `linespread=1`，这会使得排版效果过于紧凑，尤其是在使用了字面率较大的思源宋体的情形下。所以将 `linespread` 修改为了 `ctex` 宏集的默认值（即 1.3），同时调整了后文有关表述。

PS：还修改了 `.gitignore` 以支持使用 latexmk。