### PR TITLE
修改了部分样式, 增加了一些细节的说明

### DIFF
--- a/LaTeX-cn/Head.tex
+++ b/LaTeX-cn/Head.tex
@@ -254,7 +254,8 @@
     % citation & index: natbib, imakeidx
     setcitestyle,printindex,
     % Other packages
-    hologo,lettrine,endfirsthead,endhead,endlastfoot,columncolor,rowcolors,modulolinenumbers,MakeShortVerb,tikz
+    hologo,lettrine,endfirsthead,endhead,endlastfoot,columncolor,rowcolors,modulolinenumbers,MakeShortVerb,tikz,Hologo
+    %% 增加了 Hologo, 使得 Hologo 处的 codeshow 有高亮 
   }
 }
 

--- a/LaTeX-cn/Head.tex
+++ b/LaTeX-cn/Head.tex
@@ -255,7 +255,6 @@
     setcitestyle,printindex,
     % Other packages
     hologo,lettrine,endfirsthead,endhead,endlastfoot,columncolor,rowcolors,modulolinenumbers,MakeShortVerb,tikz,Hologo
-    %% 增加了 Hologo, 使得 Hologo 处的 codeshow 有高亮 
   }
 }
 

--- a/LaTeX-cn/chapters/LaTeX-Basics.tex
+++ b/LaTeX-cn/chapters/LaTeX-Basics.tex
@@ -1278,6 +1278,12 @@ Verbatim between this pair of verts: |#\?*^|
 \label{sec:include}
 文档拆分只需要在主文件中使用\latexline{input\{filename.tex\}}或\latexline{include\{filename\}}命令，后者不写扩展名默认为.tex。两者区别在于\latexline{include}命令将会插入\latexline{clearpage}再读取文件。
 
+其中 filename 可以为相对路径，如 \verb|./chapter1|，\verb|../tikz|，也可以为绝对路径，如 \verb|D:/latex/chapter1|，但是注意，在使用 \latexline{include\{filename\}} 的时候，尽量不要选择在该文档父目录中的文件，比如要在 \verb|dir/subdir/main.tex| 中使用\latexline{include\{dir/filename\}}会因为安全问题导致无法在文件夹 \verb|dir/| 中生成辅助文件\verb|filename.aux|导致编译失败，在这时应该尝试调整文章层级结构，如果有十分必要的理由这么做的话，在编译的时候可以使用
+\begin{verbatim}
+  openout_any=a xelatex(pdflatex) mainfilename
+\end{verbatim}
+临时修改\verb|openout_any|的值，该选项可以在 \verb|texmf.cnf| 中查看它的说明，但是不推荐在\verb|texmf.cnf|中修改，这可能会导致系统安全问题, 而\latexline{input\{filename.tex\}}不受这一点的影响。更多说明可以看\href{https://tex.stackexchange.com/questions/2209/how-can-i-include-the-file-somedir-file-tex-in-the-file-somedir-subdir-another}{\TeX SX 上的回答}以及\href{http://www.texfaq.org/FAQ-includeother}{\TeX faq上的说明}。
+
 拆分的优势在于可以根据chapter（或其他）分为多个文件，省去了长文档浏览时的一些不便。你也可以把整个导言区做成一个文件，然后在不同的\LaTeX\ 文档中反复使用，即充当模板的功能。你还可以把较长的tikz绘图代码写到一个tex中，在需要时\latexline{input}即可。
 
 在导言区定义\latexline{includeonly}加上filename，可以确保只引入列表中的文件。在被引入文件的最后加入\latexline{endinput}命令，其后的内容会被忽略。

--- a/LaTeX-cn/chapters/LaTeX-Basics.tex
+++ b/LaTeX-cn/chapters/LaTeX-Basics.tex
@@ -186,10 +186,10 @@ a\textasciitilde b
 英文单引号并不使用两个\verb|'|符号组合。左单引号是重音符\verb|`|（键盘上数字1左侧），而右单引号是常用的引号符。英文中，\RED{左双引号就是连续两个重音符}。
 
 英文下的引号嵌套需要借助\latexline{thinspace}命令分隔，比如：
-\begin{verbatim}
+\begin{codeshow}[listing side text, listing options={escapeinside=++}]
 ``\thinspace`Max' is here.''
-\end{verbatim}
-
+\end{codeshow}
+% 这里临时修改了listing的escapeinside, 使得这一行代码也可以被 codeshow 环境表示, 也使得行文风格更加统一
 中文下的单引号和双引号你可以用中文输入法直接输入。
 
 \subsection{破折、省略号与短横}
@@ -960,7 +960,7 @@ book文档类还提供了以下的命令：
 \begin{feai}
 \item 可选参数\textbf{对齐方式}：[t] 表示表格上端与所在行的网格线对齐。如果与它同一行的有文字的话，文字是与表格上端同高的。如果使用参数 [b]，就是下端同高。[c] 是中央同高。t=top, b=buttom, c=center.
 \item 必选参数\textbf{列格式}：用竖线符号“|”来表示竖直表线，连续两个“|”表示双竖直表线。最右边留空了，表示没有竖直表线。或者你可以使用“@\{\}”表示没有竖直表线。你也可以用“@\{-\}”这样的形式把竖直表线替换成“-”，具体效果不再展示。而此处的l、c、r分别表示从左往右一共三列，分别\textbf{左对齐、居中对齐、右对齐}文字。在使用l、c、r时，表格宽度会自动调整。你可以用"p{2em}"这样的命\textbf{指定某一列的宽度}，这时文字自动左对齐。注意：单元格中的文字默认向上水平表线对齐，即竖直居上。
-\item 在tabular环境内部，命令\latexline{hline}来绘制水平表线。命令\latexline{cline\{i-j\}}用于绘制横跨从i到j行的水平表线。两个连续的\latexline{hline}命令可以画双线，但是双线之间相交时可能存在问题。
+\item 在tabular环境内部，命令\latexline{hline}来绘制水平表线。命令\latexline{cline\{i-j\}}用于绘制横跨从i到j列的水平表线。两个连续的\latexline{hline}命令可以画双线，但是双线之间相交时可能存在问题。
 \item 在tabular环境内部，命令"\texttt{\&}"用于把光标跳入该行下一列的单元格。每行的最后请使用两个反斜杠命令跳入下一行。命令\latexline{hline}或\latexline{cline}不能算作一行，因此它们后面没有附加换行命令。
 \item 在tabular环境内部，跨列命令\latexline{multicolumn\{number\}\{format\}\{text\}}用于以format格式合并该行的number个单元格，并在合并后的单元格中写入文本text。如果一行有了跨列命令，请注意相应地减少"\texttt{\&}"的数量。
 \end{feai}

--- a/LaTeX-cn/chapters/LaTeX-Basics.tex
+++ b/LaTeX-cn/chapters/LaTeX-Basics.tex
@@ -1278,11 +1278,11 @@ Verbatim between this pair of verts: |#\?*^|
 \label{sec:include}
 文档拆分只需要在主文件中使用\latexline{input\{filename.tex\}}或\latexline{include\{filename\}}命令，后者不写扩展名默认为.tex。两者区别在于\latexline{include}命令将会插入\latexline{clearpage}再读取文件。
 
-其中 filename 可以为相对路径，如 \verb|./chapter1|，\verb|../tikz|，也可以为绝对路径，如 \verb|D:/latex/chapter1|，但是注意，在使用 \latexline{include\{filename\}} 的时候，尽量不要选择在该文档父目录中的文件，比如要在 \verb|dir/subdir/main.tex| 中使用\latexline{include\{dir/filename\}}会因为安全问题导致无法在文件夹 \verb|dir/| 中生成辅助文件\verb|filename.aux|导致编译失败，在这时应该尝试调整文章层级结构，如果有十分必要的理由这么做的话，在编译的时候可以使用
+其中 filename 可以是相对路径，如 \verb|./chapter1|，\verb|../tikz|；也可以是绝对路径，如 \verb|D:/latex/chapter1|。但是注意，在使用\latexline{include\{filename\}}时，尽量不要选择在该文档父目录中的文件。例如，在 \verb|dir/subdir/main.tex| 中使用\latexline{include\{dir/filename\}}，会因安全问题无法在文件夹 \verb|dir/| 中生成辅助文件 \verb|filename.aux|，进而导致编译失败。在这时应该尝试调整文章层级结构，如果有十分必要的理由这么做的话，在编译的时候可以使用
 \begin{verbatim}
   openout_any=a xelatex(pdflatex) mainfilename
 \end{verbatim}
-临时修改\verb|openout_any|的值，该选项可以在 \verb|texmf.cnf| 中查看它的说明，但是不推荐在\verb|texmf.cnf|中修改，这可能会导致系统安全问题, 而\latexline{input\{filename.tex\}}不受这一点的影响。更多说明可以看\href{https://tex.stackexchange.com/questions/2209/how-can-i-include-the-file-somedir-file-tex-in-the-file-somedir-subdir-another}{\TeX SX 上的回答}以及\href{http://www.texfaq.org/FAQ-includeother}{\TeX faq上的说明}。
+临时修改 \verb|openout_any| 的值，该选项可以在 \verb|texmf.cnf| 中查看它的说明，但是不推荐在 \verb|texmf.cnf| 中修改，这可能会导致系统安全问题, 而\latexline{input\{filename.tex\}}不受这一点的影响。更多说明可以看\href{https://tex.stackexchange.com/questions/2209/how-can-i-include-the-file-somedir-file-tex-in-the-file-somedir-subdir-another}{\TeX SX 上的回答}以及\href{http://www.texfaq.org/FAQ-includeother}{\TeX faq上的说明}。
 
 拆分的优势在于可以根据chapter（或其他）分为多个文件，省去了长文档浏览时的一些不便。你也可以把整个导言区做成一个文件，然后在不同的\LaTeX\ 文档中反复使用，即充当模板的功能。你还可以把较长的tikz绘图代码写到一个tex中，在需要时\latexline{input}即可。
 

--- a/LaTeX-cn/chapters/Play-with-Math.tex
+++ b/LaTeX-cn/chapters/Play-with-Math.tex
@@ -395,19 +395,6 @@ x-1, & x<0
 \end{align}
 \end{codeshow}
 
-但是在\envi{align}及其衍生环境中，要将\&放在二元关系符的前面，如果放在后面会导致关系符与后面字母的间距出现问题：
-
-\begin{codeshow}
-\begin{align*}
-  a^2   &= a\cdot a \\
-        &= a*a      
-\end{align*}
-\begin{align*}
-  a^2   =& a\cdot a \\
-        =& a*a      
-\end{align*}
-\end{codeshow}
-
 \LaTeX\ 中长公式不能自动换行\footnote{不过\pkg{breqn}宏包的\envi{dmath}环境可以实现自动换行，读者可以自行尝试效果。}，请如上自行指定断行位置和缩进距离。
 
 至于多行公式换页，可以在导言区加上\latexline{allowdisplaybreaks}实现（可选参数：1为尽量避免换页，2至4为倾向于换页），或在特定位置加上\latexline{displaybreak}（可选参数：0为允许在下个换行符后换页，但不倾向换页；2-3介中；4为强制换页）。两种的默认可选参数都是4。
@@ -422,19 +409,7 @@ x-1, & x<0
 \end{align}
 \end{codeshow}
 
-如果你想让编号显示在这三行的中间而不是最下面一行，可以尝试把公式写在\envi{aligned}或者\envi{gathered}环境中，然后再嵌套到\envi{equation}环境内:
-
-\begin{codeshow}
-\begin{equation}
-  \begin{aligned}
-    a^2  &= a\cdot a \\
-         &= a*a      \\
-         &= a^2
-  \end{aligned}
-\end{equation}
-\end{codeshow}
-
-如果你根本不想给多行公式编号，尝试\envi{align*}环境。
+如果你想让编号显示在这三行的中间而不是最下面一行，可以尝试把公式写在\envi{aligned}或者\envi{gathered}环境中，然后再嵌套到\envi{equation}环境内。如果你根本不想给多行公式编号，尝试\envi{align*}环境。
 
 另外，\pkg{amsmath}宏包的\envi{multline}环境将自动把编号放在末行。首行左对齐，末行右对齐，中间的行居中。
 \begin{codeshow}

--- a/LaTeX-cn/chapters/Play-with-Math.tex
+++ b/LaTeX-cn/chapters/Play-with-Math.tex
@@ -395,6 +395,19 @@ x-1, & x<0
 \end{align}
 \end{codeshow}
 
+但是在\envi{align}及其衍生环境中，要将\&放在二元关系符的前面，如果放在后面会导致关系符与后面字母的间距出现问题：
+
+\begin{codeshow}
+\begin{align*}
+  a^2   &= a\cdot a \\
+        &= a*a      
+\end{align*}
+\begin{align*}
+  a^2   =& a\cdot a \\
+        =& a*a      
+\end{align*}
+\end{codeshow}
+
 \LaTeX\ 中长公式不能自动换行\footnote{不过\pkg{breqn}宏包的\envi{dmath}环境可以实现自动换行，读者可以自行尝试效果。}，请如上自行指定断行位置和缩进距离。
 
 至于多行公式换页，可以在导言区加上\latexline{allowdisplaybreaks}实现（可选参数：1为尽量避免换页，2至4为倾向于换页），或在特定位置加上\latexline{displaybreak}（可选参数：0为允许在下个换行符后换页，但不倾向换页；2-3介中；4为强制换页）。两种的默认可选参数都是4。
@@ -409,7 +422,19 @@ x-1, & x<0
 \end{align}
 \end{codeshow}
 
-如果你想让编号显示在这三行的中间而不是最下面一行，可以尝试把公式写在\envi{aligned}或者\envi{gathered}环境中，然后再嵌套到\envi{equation}环境内。如果你根本不想给多行公式编号，尝试\envi{align*}环境。
+如果你想让编号显示在这三行的中间而不是最下面一行，可以尝试把公式写在\envi{aligned}或者\envi{gathered}环境中，然后再嵌套到\envi{equation}环境内:
+
+\begin{codeshow}
+\begin{equation}
+  \begin{aligned}
+    a^2  &= a\cdot a \\
+         &= a*a      \\
+         &= a^2
+  \end{aligned}
+\end{equation}
+\end{codeshow}
+
+如果你根本不想给多行公式编号，尝试\envi{align*}环境。
 
 另外，\pkg{amsmath}宏包的\envi{multline}环境将自动把编号放在末行。首行左对齐，末行右对齐，中间的行居中。
 \begin{codeshow}

--- a/LaTeX-cn/chapters/Play-with-Math.tex
+++ b/LaTeX-cn/chapters/Play-with-Math.tex
@@ -395,19 +395,6 @@ x-1, & x<0
 \end{align}
 \end{codeshow}
 
-但是在\envi{align}及其衍生环境中，要将\&放在二元关系符的前面，如果放在后面会导致关系符与后面字母的间距出现问题：
-
-\begin{codeshow}
-\begin{align*}
-  a^2   &= a\cdot a \\
-        &= a*a      
-\end{align*}
-\begin{align*}
-  a^2   =& a\cdot a \\
-        =& a*a      
-\end{align*}
-\end{codeshow}
-
 \LaTeX\ 中长公式不能自动换行\footnote{不过\pkg{breqn}宏包的\envi{dmath}环境可以实现自动换行，读者可以自行尝试效果。}，请如上自行指定断行位置和缩进距离。
 
 至于多行公式换页，可以在导言区加上\latexline{allowdisplaybreaks}实现（可选参数：1为尽量避免换页，2至4为倾向于换页），或在特定位置加上\latexline{displaybreak}（可选参数：0为允许在下个换行符后换页，但不倾向换页；2-3介中；4为强制换页）。两种的默认可选参数都是4。

--- a/LaTeX-cn/chapters/Play-with-Math.tex
+++ b/LaTeX-cn/chapters/Play-with-Math.tex
@@ -186,8 +186,8 @@ $\sqrt[\leftroot{-2}\uproot{2} \beta]{k}$
 
 \begin{codeshow}
 $\overline{m+n}$ \\
-$\underbrace{a_1+\ldots+a_n}_{n}$
-$\overbrace{a_1+\ldots+a_n}^{n}$
+$\underbrace{a_1+\cdots+a_n}_{n}$
+$\overbrace{a_1+\cdots+a_n}^{n}$
 % 可选参数：线宽；竖直空距
 $\underbracket[0.4pt][1ex]
   {a_1+\cdots+a_n}_n$
@@ -349,12 +349,14 @@ x & -y\\ y & x\end{smallmatrix}
 \right)$ 可以显示在行内。
 \end{codeshow}
 
-最后，一种带边注的矩阵\latexline{bordermatrix}，用法有些奇怪：
+一种带边注的矩阵\latexline{bordermatrix}，用法有些奇怪：
 \begin{codeshow}
 \[\bordermatrix{& 1 & 2\cr
 1 & A & B \cr
 2 & C & D \cr} \]
 \end{codeshow}
+
+最后，如果想排出更好看优雅的矩阵，可以参考宏包\pkg{nicematrix}。或者想用简单的方法输入一些特殊矩阵， 可以参考宏包\pkg{physics}，这里不过多介绍。
 
 \subsection{分段函数与联立方程}
 用\envi{cases}环境书写分段函数，它自动生成一个比\latexline{left\{}更紧凑的花括号：


### PR DESCRIPTION
1. 修改了在介绍引号时因为 `escapeinside=`` ` 导致的 `codeshow` 环境无法正确输出的设置, 也在 `moretexsc` 中添加了 `Hologo` 使得 `\Hologo` 可以在 `codeshow` 环境中正确高亮;
2. 增加了对 `\include` 的说明
3. 修改水平括号部分的 `\ldots` 为 `\cdots`, 顺便提了一句 `nicematrix` 与 `physics` 宏包
4. 增加了 `align` 环境中 `&` 的位置的说明, 给了一个 `equation` 环境套 `aligned` 环境的例子
5. `\cline{i-j}`命令应该是横跨 i 到 j 列的吧……或者是我理解有一些偏差